### PR TITLE
Add JSON import support to annotation tool

### DIFF
--- a/Annotation_tool.html
+++ b/Annotation_tool.html
@@ -147,7 +147,7 @@ tr:hover {
 <body>
     <h1>Annotation Tool</h1>
     <p>Please upload dialogue file.</p>
-    <input type="file" id="file-input" accept=".xlsx, .xls" />
+    <input type="file" id="file-input" accept=".xlsx, .xls, .csv, .json" />
     <button id="confirm-button">Show content</button>
 
     <input type="text" id="custom-label-name" placeholder="Enter custom label name" />


### PR DESCRIPTION
## Summary
- allow JSON or CSV files to be uploaded in the annotation tool
- convert uploaded JSON dialogue format to the existing speaker/content table

## Testing
- `git status --short`
