### PR TITLE
Remove remote font import

### DIFF
--- a/Annotation_tool.html
+++ b/Annotation_tool.html
@@ -141,7 +141,6 @@ tr:hover {
     display: block;
     margin: 20px 0;
 }
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- remove Google Fonts import so annotation tool works offline

## Testing
- `python -m py_compile $(git ls-files '*.py')`