### PR TITLE
Remove external font import from annotation tool

### DIFF
--- a/Annotation_tool.html
+++ b/Annotation_tool.html
@@ -5,7 +5,7 @@
 <title>Annotation</title>
 <style>
  body {
-    font-family: 'Roboto', sans-serif;
+    font-family: Arial, sans-serif;
     background-color: #f7f7f7;
     color: #333;
     line-height: 1.6;
@@ -141,7 +141,6 @@ tr:hover {
     display: block;
     margin: 20px 0;
 }
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- update Annotation_tool to use built-in fonts
- remove Google Fonts reference so tool can run offline

## Testing
- `pytest -q` *(fails: command not found)*