### PR TITLE
Add gradio dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ seaborn
 openpyxl
 python-docx
 tensorflow
+gradio


### PR DESCRIPTION
## Summary
- include `gradio` in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest` *(fails: command not found)*