### PR TITLE
Add CLI arguments to rename and conversion scripts

### DIFF
--- a/Rename.py
+++ b/Rename.py
@@ -1,25 +1,45 @@
 import os
+import argparse
 import pandas as pd
 
-def rename_and_record_files(folder_path):
-   
-    files = [f for f in os.listdir(folder_path) if f.endswith('.xlsx') or f.endswith('.xls')]
+def rename_and_record_files(input_dir: str, output_dir: str) -> None:
+    """Rename Excel files sequentially and save a record Excel file."""
 
-    
+    os.makedirs(output_dir, exist_ok=True)
+
+    files = [
+        f for f in os.listdir(input_dir) if f.lower().endswith(".xlsx") or f.lower().endswith(".xls")
+    ]
+
     records = []
 
     for i, file in enumerate(files, start=1):
         new_name = f"G{i}.xlsx"
-        original_path = os.path.join(folder_path, file)
-        new_path = os.path.join(folder_path, new_name)
+        original_path = os.path.join(input_dir, file)
+        new_path = os.path.join(output_dir, new_name)
 
         os.rename(original_path, new_path)
-        records.append({'Original Name': file, 'New Name': new_name})
+        records.append({"Original Name": file, "New Name": new_name})
 
-    
     df = pd.DataFrame(records)
-    df.to_excel(os.path.join(folder_path, 'renaming_record.xlsx'), index=False)
+    df.to_excel(os.path.join(output_dir, "renaming_record.xlsx"), index=False)
 
 
-folder_path = 'Renamed_output'  
-rename_and_record_files(folder_path)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Rename Excel files sequentially")
+    parser.add_argument(
+        "--input-dir",
+        default="Renamed_output",
+        help="Directory containing the Excel files to rename",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="Renamed_output",
+        help="Directory where renamed files and the record will be placed",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    rename_and_record_files(args.input_dir, args.output_dir)

--- a/word_to_excel.py
+++ b/word_to_excel.py
@@ -1,5 +1,6 @@
 import os
 import re
+import argparse
 from docx import Document
 import pandas as pd
 
@@ -33,7 +34,7 @@ def process_document_with_id(doc_path):
     # Convert the data to a DataFrame
     return pd.DataFrame(data)
 
-def process_all_documents(input_folder, output_folder):
+def process_all_documents(input_folder: str, output_folder: str) -> None:
     # Ensure output directory exists
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
@@ -48,9 +49,23 @@ def process_all_documents(input_folder, output_folder):
             output_file = os.path.join(output_folder, filename.replace('.docx', '.xlsx'))
             df.to_excel(output_file, index=False)
 
-# Define input and output folders
-input_folder = 'Input'  # Replace with your actual input folder path
-output_folder = 'Output'  # Replace with your actual output folder path
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert Word transcripts to Excel with dialogue IDs"
+    )
+    parser.add_argument(
+        "--input-dir",
+        default="Input",
+        help="Directory containing the Word files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="Output",
+        help="Directory where the Excel files will be saved",
+    )
+    return parser.parse_args()
 
-# Process all Word documents in the input folder
-process_all_documents(input_folder, output_folder)
+
+if __name__ == "__main__":
+    args = parse_args()
+    process_all_documents(args.input_dir, args.output_dir)


### PR DESCRIPTION
## Summary
- add argparse support to `Rename.py`
- move files while renaming and save record in output directory
- add argparse support to `word_to_excel.py` for better command-line usage

## Testing
- `python -m py_compile Rename.py word_to_excel.py`
