### PR TITLE
Add convert-only option and main guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ pip install -r requirements.txt
    ```bash
    python preprocessing.py --input-dir "SLDEA Data" --output-dir csv_output
    ```
-   This will create a `csv_output` folder with the converted CSV files.
+   This will create a `csv_output` folder with the converted CSV files. Pass
+   `--convert-only` if you want to skip the analysis section of the script.
 
 2. **Annotate**
    Open `Annotation_tool.html` in your browser. You can load CSV files and apply labels using the interface.
@@ -85,7 +86,8 @@ If you are new to Python, follow these steps to run each tool in order:
    ```bash
    python preprocessing.py --input-dir "SLDEA Data" --output-dir csv_output
    ```
-   The converted CSV files will appear inside the `csv_output` folder.
+   The converted CSV files will appear inside the `csv_output` folder. Use
+   the optional `--convert-only` flag to run just the conversion step.
 4. **Annotate dialogues** – Double click `Annotation_tool.html`. Your browser will open the annotation interface. Load a CSV file, apply labels, and save your work.
 5. **Train a model** – Open either `dialogue_pred.ipynb` or `ESL_AddedExperinments.ipynb` in Jupyter Notebook and run the cells one by one using the annotated CSV files from the previous step. A model file will be generated.
 6. **Evaluate a corpus** – Use the evaluation tab in `app.py` or the final notebook cells to load the saved model together with new CSV data. Accuracy numbers will be printed.

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -70,132 +70,102 @@ def parse_args():
         default="csv_output",
         help="Directory where converted CSV files will be placed",
     )
+    parser.add_argument(
+        "--convert-only",
+        action="store_true",
+        help="Only convert Excel files and skip the analysis step",
+    )
     return parser.parse_args()
 
 
-args = parse_args()
-csv_files = convert_excels_to_csv(args.input_dir, args.output_dir)
-sys.exit(0)
+def main():
+    args = parse_args()
+    csv_files = convert_excels_to_csv(args.input_dir, args.output_dir)
 
-# Load one of the generated CSVs if available so subsequent analysis does not
-# fail. Replace or extend this step with your own data loading logic.
-if csv_files:
-    df = pd.read_csv(csv_files[0])
-else:
-    df = pd.DataFrame()
+    if args.convert_only:
+        return
+
+    # Load one of the generated CSVs if available so subsequent analysis does not
+    # fail. Replace or extend this step with your own data loading logic.
+    if csv_files:
+        df = pd.read_csv(csv_files[0])
+    else:
+        df = pd.DataFrame()
 
 # Placeholder DataFrame. Replace this with your own summarised data structure
 # that aggregates label counts for each dialogue segment.
-summary_label_counts_by_segment = pd.DataFrame()
+    summary_label_counts_by_segment = pd.DataFrame()
 
 
-def assign_tone(row):
-    if row['backchannels'] > 0 or row['code-switching for communicative purposes'] > 0 or row['collaborative finishes'] > 0:
-        return 'Informal'
-    elif row['subordinate clauses'] > 0 or row['impersonal subject + non-factive verb + NP'] > 0:
-        return 'Formal'
-    else:
-        return 'Neutral'  # Default to Neutral if none of the criteria match
+    def assign_tone(row):
+        if row['backchannels'] > 0 or row['code-switching for communicative purposes'] > 0 or row['collaborative finishes'] > 0:
+            return 'Informal'
+        elif row['subordinate clauses'] > 0 or row['impersonal subject + non-factive verb + NP'] > 0:
+            return 'Formal'
+        else:
+            return 'Neutral'  # Default to Neutral if none of the criteria match
 
 # Apply the function to each segment
-summary_label_counts_by_segment['Tone'] = summary_label_counts_by_segment.apply(assign_tone, axis=1)
+    summary_label_counts_by_segment['Tone'] = summary_label_counts_by_segment.apply(assign_tone, axis=1)
 
 # Overview of tone assignments
-tone_assignments = summary_label_counts_by_segment['Tone'].value_counts()
+    tone_assignments = summary_label_counts_by_segment['Tone'].value_counts()
 
 # Visualize the distribution of assigned tones across segments
-plt.figure(figsize=(8, 5))
-tone_assignments.plot(kind='bar')
-plt.title('Distribution of Assigned Tones Across Dialogue Segments')
-plt.xlabel('Tone')
-plt.ylabel('Number of Segments')
-plt.xticks(rotation=0)
-plt.show()
+    plt.figure(figsize=(8, 5))
+    tone_assignments.plot(kind='bar')
+    plt.title('Distribution of Assigned Tones Across Dialogue Segments')
+    plt.xlabel('Tone')
+    plt.ylabel('Number of Segments')
+    plt.xticks(rotation=0)
+    plt.show()
 
 # Now that we have assigned tones, we could explore the relationship between these tones and specific labels
 # This step is illustrative and based on the simplified criteria for tone assignment
-tone_assignments
+    tone_assignments
 
 
 # Assuming `df` is a DataFrame with dialogue identifiers and the constructed dialogue-level labels
 
 # Feature Engineering: Summarize token-level labels into dialogue-level features
-features = df.groupby('dialogue_id').agg({
+    features = df.groupby('dialogue_id').agg({
     'token_label_type1': 'sum',
     'token_label_type2': 'sum',
     # Add more as needed
 })
 
 # Assume `dialogue_labels` is a DataFrame with our dialogue-level labels
-dialogue_labels = df.groupby('dialogue_id').agg({
+    dialogue_labels = df.groupby('dialogue_id').agg({
     'OverallToneChoice': 'first',  # Assuming a method to assign these labels
     'TopicExtension': 'first'
 })
 
 # Join features with labels
-data_for_regression = features.join(dialogue_labels)
+    data_for_regression = features.join(dialogue_labels)
 
 # Split data into features (X) and labels (y)
-X = data_for_regression.drop(['OverallToneChoice', 'TopicExtension'], axis=1)
-y = data_for_regression[['OverallToneChoice', 'TopicExtension']]
+    X = data_for_regression.drop(['OverallToneChoice', 'TopicExtension'], axis=1)
+    y = data_for_regression[['OverallToneChoice', 'TopicExtension']]
 
 # Regression analysis (simplified)
-from sklearn.model_selection import train_test_split
-from sklearn.linear_model import LinearRegression
+    from sklearn.model_selection import train_test_split
+    from sklearn.linear_model import LinearRegression
 
 # Splitting dataset into training and testing sets
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
 # Linear regression model for 'Overall Tone Choice'
-model_tone = LinearRegression().fit(X_train, y_train['OverallToneChoice'])
+    model_tone = LinearRegression().fit(X_train, y_train['OverallToneChoice'])
 
 # Predict and evaluate 'Overall Tone Choice'
 # (Evaluation steps would go here)
 
 # Repeat for 'Topic Extension'
-model_topic = LinearRegression().fit(X_train, y_train['TopicExtension'])
+    model_topic = LinearRegression().fit(X_train, y_train['TopicExtension'])
 
-# Predict and evaluate 'Topic Extension'
-# (Evaluation steps would go here)
+    # Predict and evaluate 'Topic Extension'
 
 
-# Assuming `df` is a DataFrame with dialogue identifiers and the constructed dialogue-level labels
-
-# Feature Engineering: Summarize token-level labels into dialogue-level features
-features = df.groupby('dialogue_id').agg({
-    'token_label_type1': 'sum',
-    'token_label_type2': 'sum',
-    # Add more as needed
-})
-
-# Assume `dialogue_labels` is a DataFrame with our dialogue-level labels
-dialogue_labels = df.groupby('dialogue_id').agg({
-    'OverallToneChoice': 'first',  # Assuming a method to assign these labels
-    'TopicExtension': 'first'
-})
-
-# Join features with labels
-data_for_regression = features.join(dialogue_labels)
-
-# Split data into features (X) and labels (y)
-X = data_for_regression.drop(['OverallToneChoice', 'TopicExtension'], axis=1)
-y = data_for_regression[['OverallToneChoice', 'TopicExtension']]
-
-# Regression analysis (simplified)
-from sklearn.model_selection import train_test_split
-from sklearn.linear_model import LinearRegression
-
-# Splitting dataset into training and testing sets
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-
-# Linear regression model for 'Overall Tone Choice'
-model_tone = LinearRegression().fit(X_train, y_train['OverallToneChoice'])
-
-# Predict and evaluate 'Overall Tone Choice'
-# (Evaluation steps would go here)
-
-# Repeat for 'Topic Extension'
-model_topic = LinearRegression().fit(X_train, y_train['TopicExtension'])
-
-# Predict and evaluate 'Topic Extension'
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- refactor `preprocessing.py` to allow running only conversion
- add `--convert-only` argument and main guard
- clean up duplicate code
- document the new option in the README

## Testing
- `python -m py_compile preprocessing.py`
- `pytest -q` *(fails: command not found)*